### PR TITLE
store git commit in the lockfile

### DIFF
--- a/lua-rover-scm-1.rockspec
+++ b/lua-rover-scm-1.rockspec
@@ -32,7 +32,8 @@ build = {
       ["rover.setup"] = "src/rover/setup.lua",
       ["rover.tree"] = "src/rover/tree.lua",
       ["rover.update"] = "src/rover/update.lua",
-      ["rover.vendor"] = "src/rover/vendor.lua"
+      ["rover.vendor"] = "src/rover/vendor.lua",
+      ["luarocks.fetch.git"] = "src/luarocks/fetch/git.lua",
    },
    install = {
       bin = {

--- a/src/luarocks/fetch/git.lua
+++ b/src/luarocks/fetch/git.lua
@@ -1,0 +1,92 @@
+
+--- Fetch back-end for retrieving sources from GIT.
+local git = {}
+
+local unpack = unpack or table.unpack
+
+local fs = require("luarocks.fs")
+local dir = require("luarocks.dir")
+local util = require("luarocks.util")
+
+--- Git >= 1.7.10 can clone a branch **or tag**, < 1.7.10 by branch only. We
+-- need to know this in order to build the appropriate command; if we can't
+-- clone by tag then we'll have to issue a subsequent command to check out the
+-- given tag.
+-- @return boolean: Whether Git can clone by tag.
+local function git_can_clone_by_tag(git_cmd)
+  local version_string = io.popen(fs.Q(git_cmd)..' --version'):read()
+  local major, minor, tiny = version_string:match('(%d-)%.(%d+)%.?(%d*)')
+  major, minor, tiny = tonumber(major), tonumber(minor), tonumber(tiny) or 0
+  local value = major > 1 or (major == 1 and (minor > 7 or (minor == 7 and tiny >= 10)))
+  git_can_clone_by_tag = function() return value end
+  return value
+end
+
+--- Download sources for building a rock, using git.
+-- @param rockspec table: The rockspec table
+-- @param extract boolean: Unused in this module (required for API purposes.)
+-- @param dest_dir string or nil: If set, will extract to the given directory.
+-- @return (string, string) or (nil, string): The absolute pathname of
+-- the fetched source tarball and the temporary directory created to
+-- store it; or nil and an error message.
+function git.get_sources(rockspec, extract, dest_dir, depth)
+  assert(type(rockspec) == "table")
+  assert(type(dest_dir) == "string" or not dest_dir)
+
+  local git_cmd = rockspec.variables.GIT
+  local name_version = rockspec.name .. "-" .. rockspec.version
+  local module = dir.base_name(rockspec.source.url)
+  -- Strip off .git from base name if present
+  module = module:gsub("%.git$", "")
+
+  local ok, err_msg = fs.is_tool_available(git_cmd, "Git")
+  if not ok then
+    return nil, err_msg
+  end
+
+  local store_dir
+  if not dest_dir then
+    store_dir = fs.make_temp_dir(name_version)
+    if not store_dir then
+      return nil, "Failed creating temporary directory."
+    end
+    util.schedule_function(fs.delete, store_dir)
+  else
+    store_dir = dest_dir
+  end
+  store_dir = fs.absolute_name(store_dir)
+  local ok, err = fs.change_dir(store_dir)
+  if not ok then return nil, err end
+
+  local command = {fs.Q(git_cmd), "clone", depth or "--depth=1", rockspec.source.url, module}
+  local tag_or_branch = rockspec.source.tag or rockspec.source.branch
+  -- If the tag or branch is explicitly set to "master" in the rockspec, then
+  -- we can avoid passing it to Git since it's the default.
+  if tag_or_branch == "master" then tag_or_branch = nil end
+  if tag_or_branch then
+    if git_can_clone_by_tag(git_cmd) then
+      -- The argument to `--branch` can actually be a branch or a tag as of
+      -- Git 1.7.10.
+      table.insert(command, 3, "--branch=" .. tag_or_branch)
+    end
+  end
+  if not fs.execute(unpack(command)) then
+    return nil, "Failed cloning git repository."
+  end
+  ok, err = fs.change_dir(module)
+  if not ok then return nil, err end
+  if tag_or_branch and not git_can_clone_by_tag() then
+    local checkout_command = {fs.Q(git_cmd), "checkout", tag_or_branch}
+    if not fs.execute(unpack(checkout_command)) then
+      return nil, 'Failed to check out the "' .. tag_or_branch ..'" tag or branch.'
+    end
+  end
+
+  fs.delete(dir.path(store_dir, module, ".git"))
+  fs.delete(dir.path(store_dir, module, ".gitignore"))
+  fs.pop_dir()
+  fs.pop_dir()
+  return module, store_dir
+end
+
+return git

--- a/src/rover/cli/update.lua
+++ b/src/rover/cli/update.lua
@@ -1,14 +1,15 @@
 local setmetatable = setmetatable
 
 local update = require('rover.update')
-local roverfile = require('rover.roverfile')
+local file = require('rover.roverfile')
 
 local _M = {}
 
 local mt = {}
 
 function mt:__call(options)
-    local lock = roverfile.read():lock()
+    local roverfile = assert(file.read(options.roverfile))
+    local lock = roverfile:lock()
     local all = true
     local dependencies = {}
 
@@ -28,6 +29,7 @@ function _M:new(parser)
     local cmd = parser:command('update', 'Update dependencies')
 
     cmd:argument('dependencies'):args("*")
+    cmd:option('--roverfile', 'Path to Roverfile', 'Roverfile')
 
     return setmetatable({ parser = parser, cmd = cmd }, mt)
 end

--- a/src/rover/dsl.lua
+++ b/src/rover/dsl.lua
@@ -15,6 +15,7 @@ local _M = {
 local mt = { __index = _M }
 
 local function root(path)
+    if path == 'Roverfile' then return nil end
     return path:gsub('/Roverfile', '')
 end
 

--- a/src/rover/install.lua
+++ b/src/rover/install.lua
@@ -54,9 +54,9 @@ function _M:call(lock, force)
 
     local tree = require('rover.tree')
 
-    for name, version in pairs(lock.dependencies) do
-        local ret, err = install(name, version, _M.DEPS_MODE, force)
-        table.insert(status, { name = name, version = version, status = ret, error = err })
+    for name, rockspec in pairs(lock.dependencies) do
+        local ret, err = install(name, rockspec.version, _M.DEPS_MODE, force)
+        table.insert(status, { name = name, version = rockspec.version, status = ret, error = err })
     end
 
     return status

--- a/src/rover/lock.lua
+++ b/src/rover/lock.lua
@@ -24,14 +24,14 @@ local dependencies_mt = {
         local str = ""
         local dependencies = {}
 
-        for name, version in pairs(t) do
-            insert(dependencies, { name = name, version = version })
+        for name, rockspec in pairs(t) do
+            insert(dependencies, { name = name, version = rockspec.version, hash = rockspec.source.hash })
         end
 
         sort(dependencies, function(a,b) return a.name < b.name end)
 
         for i=1, #dependencies do
-            str = str .. format('%s %s\n', dependencies[i].name, dependencies[i].version)
+            str = str .. format('%s %s|%s\n', dependencies[i].name, dependencies[i].version, dependencies[i].hash or '' )
         end
 
         return str
@@ -60,7 +60,10 @@ function _M.read(lockfile)
     local lock = _M.new()
 
     for line in handle:lines() do
-        local dep, err = deps.parse_dep(line)
+        local constraint, hash  = string.match(line, "^(.-)|(%w*)$")
+        local dep, err = assert(deps.parse_dep(constraint))
+
+        dep.source = { hash = hash }
 
         if dep then
             lock:add(dep)
@@ -81,18 +84,27 @@ function _M:add(dep)
     end
 
     if version then
-        self.dependencies[dep.name] = version
+        self.dependencies[dep.name] = {
+            name = dep.name, version = version, source = dep.source
+        }
     else
         return nil, 'invalid constraints'
     end
 end
 
+local function rockspec_mismatch(cache, rockspec)
+    local other = cache[rockspec.name]
+
+    return other.version ~= rockspec.version or other.source.hash ~= rockspec.source.hash
+end
+
+
 local function expand_dependencies(dep, dependencies, no_cache)
     local rockspec = rover_rockspec.find(dep.name, dep.constraints, no_cache)
 
     if not dependencies[rockspec.name] then
-        dependencies[rockspec.name] = rockspec.version
-    elseif dependencies[rockspec.name] ~= rockspec.version then
+        dependencies[rockspec.name] = rockspec
+    elseif rockspec_mismatch(dependencies, rockspec) then
         error('cannot have two '  .. rockspec.name)
     end
 

--- a/src/rover/lock.lua
+++ b/src/rover/lock.lua
@@ -11,7 +11,7 @@ local format = string.format
 local open = io.open
 
 local deps = require('luarocks.deps')
-local rover_rocspec  = require('rover.rockspec')
+local rover_rockspec = require('rover.rockspec')
 
 local _M = {
     DEFAULT_PATH = 'Roverfile.lock'
@@ -88,7 +88,7 @@ function _M:add(dep)
 end
 
 local function expand_dependencies(dep, dependencies, no_cache)
-    local rockspec = rover_rocspec.find(dep.name, dep.constraints, no_cache)
+    local rockspec = rover_rockspec.find(dep.name, dep.constraints, no_cache)
 
     if not dependencies[rockspec.name] then
         dependencies[rockspec.name] = rockspec.version
@@ -114,7 +114,7 @@ function _M:resolve(no_cache)
     for name,spec in pairs(index) do
         expand_dependencies({
             name = name,
-            constraints = rover_rocspec.parse_constraints(spec.version)
+            constraints = rover_rockspec.parse_constraints(spec.version)
         }, dependencies, no_cache or {})
     end
 

--- a/src/rover/tree.lua
+++ b/src/rover/tree.lua
@@ -3,6 +3,7 @@ local tostring = tostring
 
 local path = require('luarocks.path')
 local fs = require('luarocks.fs')
+local cfg = require("luarocks.cfg")
 
 local mt = { }
 local _M = setmetatable({
@@ -29,6 +30,9 @@ function mt.__tostring(self) return self.root or _M.root end
 function mt.__call(self, root)
     self.root = fs.absolute_name(self.tree, fs.absolute_name(root))
     path.use_tree(self.root)
+
+    -- because we are storing new field in the rockspec
+    cfg.accept_unknown_fields = true
 
     return self
 end


### PR DESCRIPTION
closes #1 

we need to lock the git reference when getting source code from git

this overrides installed luarocks git strategy with custom version, it is pretty evil but works
also it stores custom property in the rockspec so it can verify it after dependencies were installed

for the record, the new format with old rover will crash like: https://circleci.com/gh/3scale/apicast/1495
`Failed to parse constraint '2.0.rc12-1|' with error: Encountered bad constraint operator: 'nil' in '|'`