### PR TITLE
fix tree/env API

### DIFF
--- a/spec/rover/env_spec.lua
+++ b/spec/rover/env_spec.lua
@@ -1,0 +1,23 @@
+local env = require('rover.env')
+
+local tree = require('rover.tree')
+
+describe('env', function()
+  describe('path', function()
+    it('is a string', function()
+      assert.is_string(env.path(tree))
+    end)
+  end)
+
+  describe('cpath', function()
+    it('is a string', function()
+      assert.is_string(env.cpath(tree))
+    end)
+  end)
+
+  describe('bin', function()
+    it('is a string', function()
+      assert.is_string(env.bin(tree))
+    end)
+  end)
+end)

--- a/spec/rover/tree_spec.lua
+++ b/spec/rover/tree_spec.lua
@@ -1,0 +1,54 @@
+local tree = require('rover.tree')
+
+local path = require('luarocks.path')
+
+describe('tree', function()
+
+  it('works with path.rocks_dir', function()
+    local rocks_dir = path.rocks_dir(tree)
+
+    assert.is_string(rocks_dir)
+  end)
+
+  describe('.lua_dir', function()
+    it('is a string', function()
+      assert.is_string(tree.lua_dir)
+    end)
+  end)
+
+  describe('.lib_dir', function()
+    it('is a string', function()
+      assert.is_string(tree.lib_dir)
+    end)
+  end)
+
+  describe('.bin_dir', function()
+    it('is a string', function()
+      assert.is_string(tree.bin_dir)
+    end)
+  end)
+
+  describe('.rocks_dir', function()
+    it('is a string', function()
+      assert.is_string(tree.rocks_dir)
+    end)
+  end)
+
+  describe(':lua_path()', function()
+    it('returns a string', function()
+      assert.is_string(tree:lua_path())
+    end)
+  end)
+
+  describe(':lua_cpath()', function()
+    it('returns a string', function()
+      assert.is_string(tree:lua_cpath())
+    end)
+  end)
+
+  describe(':bin_path()', function()
+    it('returns a string', function()
+      assert.is_string(tree:bin_path())
+    end)
+  end)
+end)

--- a/src/rover/tree.lua
+++ b/src/rover/tree.lua
@@ -10,21 +10,38 @@ local _M = setmetatable({
     tree = 'lua_modules'
 }, mt)
 
-mt.__index = {
-    rockspec_file = path.rockspec_file,
-    lua_path = function(self)
-        return path.deploy_lua_dir(self or _M)
-    end,
-    lua_cpath = function(self)
-        return path.deploy_lib_dir(self or _M)
-    end,
-    bin_path = function(self)
-        return path.deploy_bin_dir(self or _M)
-    end,
-    rocks_dir = function(self)
-        return path.rocks_dir(tostring(self or _M))
-    end
+
+local __index = {
+  rockspec_file = path.rockspec_file,
+  lua_path = function(self)
+    return path.deploy_lua_dir(tostring(self or _M))
+  end,
+  lua_cpath = function(self)
+    return path.deploy_lib_dir(tostring(self or _M))
+  end,
+  bin_path = function(self)
+    return path.deploy_bin_dir(tostring(self or _M))
+  end,
+  rocks_path = function(self)
+    return path.rocks_dir(tostring(self or _M))
+  end
 }
+
+local __index_fn = {
+  lua_dir = __index.lua_path,
+  lib_dir = __index.lua_cpath,
+  bin_dir = __index.bin_path,
+  rocks_dir = __index.rocks_path,
+}
+
+mt.__index = function(self, key)
+  if __index_fn[key] then
+    return __index_fn[key](self)
+  else
+    return __index[key]
+  end
+end
+
 function mt.__tostring(self) return self.root or _M.root end
 
 function mt.__call(self, root)


### PR DESCRIPTION
if rover tree was set to `cfg.rock_trees` it would fail with following error:

```
ERROR: ...l/openresty/luajit/share/lua/5.1/luarocks/manif_core.lua:69: assertion failed!
stack traceback:
	...l/openresty/luajit/share/lua/5.1/luarocks/manif_core.lua:69: in function 'load_local_manifest'
	...local/openresty/luajit/share/lua/5.1/luarocks/loader.lua:58: in function 'load_rocks_trees'
	...local/openresty/luajit/share/lua/5.1/luarocks/loader.lua:172: in function 'pick_module'
	...local/openresty/luajit/share/lua/5.1/luarocks/loader.lua:238: in function <...local/openresty/luajit/share/lua/5.1/luarocks/loader.lua:237>
	[C]: in function 'require'
	/opt/app-root/src/bin/cli:14: in function 'file_gen'
	init_worker_by_lua:49: in function <init_worker_by_lua:47>
	[C]: in function 'xpcall'
	init_worker_by_lua:56: in function <init_worker_by_lua:54>
```

because `tree.rock_path` was a function and not a string.


Now the tree object should be the same as expected by luarocks.