### PR TITLE
Reset _G table to avoid invalid warning message.

### DIFF
--- a/bin/rover
+++ b/bin/rover
@@ -1,3 +1,8 @@
 #!/usr/bin/env lua
 
+-- Clean warning on openresty 1.15.8.1, where some global variables are set
+-- using ngx.timer that triggers an invalid warning message.
+-- Code related: https://github.com/openresty/lua-nginx-module/blob/61e4d0aac8974b8fad1b5b93d0d3d694d257d328/src/ngx_http_lua_util.c#L795-L839
+(getmetatable(_G) or {}).__newindex = nil
+
 require('rover.cli')(arg)


### PR DESCRIPTION
Clean warning on openresty 1.15.8.1, where some global variables are set
using ngx.timer that triggers an invalid warning message.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>