### PR TITLE
Reset _G table to avoid invalid warning message.

### DIFF
--- a/src/rover/roverfile.lua
+++ b/src/rover/roverfile.lua
@@ -1,3 +1,8 @@
+-- Clean warning on openresty 1.15.8.1, where some global variables are set
+-- using ngx.timer that triggers an invalid warning message.
+-- Code related: https://github.com/openresty/lua-nginx-module/blob/61e4d0aac8974b8fad1b5b93d0d3d694d257d328/src/ngx_http_lua_util.c#L795-L839
+(getmetatable(_G) or {}).__newindex = nil
+
 local setmetatable = setmetatable
 local load = load
 local pcall = pcall


### PR DESCRIPTION
Clean warning on openresty 1.15.8.1, where some global variables are set
using ngx.timer that triggers an invalid warning message.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>