### PR TITLE
Install: Try rock before rockspec.

### DIFF
--- a/src/rover/install.lua
+++ b/src/rover/install.lua
@@ -32,13 +32,13 @@ end
 -- search.
 local function get_dep_spec(name, version)
     local query = search.make_query(name:lower(), version)
-    query["arch"] = "rockspec"
+    query["arch"] = "rock"
     local spec = search.find_suitable_rock(query)
     if spec then
       return spec
     end
 
-    query["arch"] = "rock"
+    query["arch"] = "rockspec"
     return search.find_suitable_rock(query)
 end
 


### PR DESCRIPTION
In APIcast we have a few issues around rockspec that it's not valid at
all and dependencies are not be able to install.

With this change, by default all will be installed with rock, and if
it's not present will use the rockspec.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>