### PR TITLE
ADD a option to specified custom CFLAGS on install.

### DIFF
--- a/src/rover/cli/install.lua
+++ b/src/rover/cli/install.lua
@@ -17,6 +17,7 @@ local function format_status(status)
 end
 
 function mt:__call(options)
+    install.set_extra_cflags(os.getenv("EXTRA_CFLAGS"))
     local lock = options.roverfile .. '.lock'
     local lockfile = assert(rover_lock.read(lock))
 

--- a/src/rover/install.lua
+++ b/src/rover/install.lua
@@ -4,6 +4,7 @@ local next = next
 
 local fs = require('luarocks.fs')
 local build = require("luarocks.build")
+local cfg = require("luarocks.cfg")
 local repos = require("luarocks.repos")
 local search = require('luarocks.search')
 
@@ -80,6 +81,13 @@ local function should_install(dep, desired_groups)
     return false
 end
 
+function _M.set_extra_cflags(flag)
+  if not flag then
+    return
+  end
+
+  cfg.variables.CFLAGS =  cfg.variables.CFLAGS .. " " .. flag
+end
 
 function _M:call(lock, force, groups)
     local status = {}


### PR DESCRIPTION
APIcast has a issue that a custom CFLAGS need to be sent to gcc, in
luarocks we can use:

```
luarocks install XXX CFLAGS="XX"
```

But in this case we can't, so I added this new env variable to be able
to set custom CFLAGS

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>