### PR TITLE
Minor bug fixes

### DIFF
--- a/src/rover/lock.lua
+++ b/src/rover/lock.lua
@@ -210,6 +210,7 @@ function _M:resolve(no_cache)
     for name,spec in pairs(index) do
         local query = queries.from_dep_string(name .. " " .. spec.version)
         query.groups = spec.groups
+        query.arch.all = false
         expand_dependencies(query, dependencies, no_cache or {})
     end
 

--- a/src/rover/lock.lua
+++ b/src/rover/lock.lua
@@ -199,7 +199,7 @@ local function expand_dependencies(dep, dependencies, no_cache)
     for _, dep in pairs(missing) do
         local query = queries.new(dep.name, nil, dep.version, false, "src|rockspec")
         query.groups = groups
-        expand_dependencies(dep, dependencies, no_cache)
+        expand_dependencies(query, dependencies, no_cache)
     end
 end
 

--- a/src/rover/lock.lua
+++ b/src/rover/lock.lua
@@ -208,7 +208,7 @@ function _M:resolve(no_cache)
     local dependencies = setmetatable({}, dependencies_mt)
 
     for name,spec in pairs(index) do
-        local query = queries.from_dep_string(name .. spec.version)
+        local query = queries.from_dep_string(name .. " " .. spec.version)
         query.groups = spec.groups
         expand_dependencies(query, dependencies, no_cache or {})
     end


### PR DESCRIPTION
Including:
* Invalid query name. i.e lua-resty-iputils0.3.0   
* Empty groups
* Query returns all.rock. We currently only handle *.src.rock and *.rockspec