### PR TITLE
fix attempt to get length of field 'constraints' (a nil value)

### DIFF
--- a/src/rover/dsl.lua
+++ b/src/rover/dsl.lua
@@ -73,9 +73,10 @@ local function rockspec(name)
         spec = rockspec,
         modules = modules }, rockspec_mt)
 
+    local dependencies = rockspec.dependencies.queries
 
-    for i=1, #(rockspec.dependencies) do
-        local dep = rockspec.dependencies[i]
+    for i=1, #(dependencies) do
+        local dep = dependencies[i]
         local version = {}
 
         for c=1, #(dep.constraints) do

--- a/src/rover/lock.lua
+++ b/src/rover/lock.lua
@@ -188,7 +188,7 @@ local function expand_dependencies(dep, dependencies, no_cache)
         existing.groups = merge_groups(existing.groups, groups)
     end
 
-    local matched, missing, _ = deps.match_deps(rockspec.dependencies, rockspec.rocks_provided, nil, 'one')
+    local matched, missing, _ = deps.match_deps(rockspec.dependencies.queries, rockspec.rocks_provided, nil, 'one')
 
     for _, dep in pairs(matched) do
         local query = queries.new(dep.name, nil, dep.version, false, "src|rockspec")


### PR DESCRIPTION
## What

Fix the `constraints' (a nil value)`

```                                                                                                                       
/usr/local/openresty/luajit/bin/rover lock --roverfile=/opt/app-root/src/gateway/Roverfile                                                                    
/usr/local/openresty/luajit/bin/luajit: .../local/openresty/luajit/share/lua/5.1/rover/cli/lock.lua:12: /usr/local/openresty/luajit/share/lua/5.1/rover/dsl.lu
a:81: attempt to get length of field 'constraints' (a nil value)                                                                                              
stack traceback:                                                                                                                                              
        [C]: in function 'assert'                                                                                                                             
        .../local/openresty/luajit/share/lua/5.1/rover/cli/lock.lua:12: in function <.../local/openresty/luajit/share/lua/5.1/rover/cli/lock.lua:11>          
        /usr/local/openresty/luajit/share/lua/5.1/rover/cli.lua:33: in function </usr/local/openresty/luajit/share/lua/5.1/rover/cli.lua:27>                  
        .../luajit/lib/luarocks/rocks-5.1/lua-rover/scm-1/bin/rover:8: in main chunk                                                                          
        [C]: at 0x55fca9408d10                                                                                                                                
make: *** [Makefile:215: /opt/app-root/src/gateway/Roverfile.lock] Error 1                                                                                    

```